### PR TITLE
Make handler function FnOnce

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,7 +71,7 @@ pub type Response = http::Response<Vec<u8>>;
 /// print to stdout. If this programme is not called as CGI (e.g. missing required
 /// environmental variables), it will panic.
 pub fn handle<F>(func: F) 
-    where F: Fn(Request) -> Response
+    where F: FnOnce(Request) -> Response
 {
     let env_vars: HashMap<String, String> = std::env::vars().collect();
 


### PR DESCRIPTION
making the handler `FnOnce` allows moving variables into the handler, especially for structs without the `Copy` trait
e.g.
```rust
struct Config {
    pub response: &'static str
}

fn main() {
    let config = Config { response: "foo" };
    cgi::handle(move |_request: cgi::Request| -> cgi::Response {
        let s = config;
        cgi::html_response(200, s.response)
    })
}
```